### PR TITLE
added ability to use the entire grunt config in templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gruntfile"
   ],
   "dependencies": {
+    "underscore": "^1.6.0",
     "underscore.string": "^2.3.3",
     "inquirer": "^0.4.1"
   }

--- a/tasks/generate.js
+++ b/tasks/generate.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var path = require( 'path' );
+var _ = require( 'underscore' );
 var _s = require( 'underscore.string' );
 var inquirer = require( 'inquirer' );
 
@@ -113,7 +114,7 @@ module.exports = function( grunt ){
     data.meta.fqn = data.meta.package + '.' + data.meta.className;
 
     var processed = grunt.template.process( grunt.file.read( source.absolute ), {
-      data : data
+      data : _.extend({}, grunt.config.data, data)
     } );
 
     grunt.verbose.writeln( 'Template data:'.cyan, '\n', data );

--- a/test/fixtures/Gruntfile.js
+++ b/test/fixtures/Gruntfile.js
@@ -22,7 +22,8 @@ module.exports = function( grunt ){
           "override"                : '/generated/overridden/mapped',
           "override/ExtraModule"    : 'overridden',
           "constructed"             : ':dir/constructed',
-          "constructed/ExtraModule" : ':dir/constructed/stub_:basename'
+          "constructed/ExtraModule" : ':dir/constructed/stub_:basename',
+          "interpolate"             : 'interpolated'
         }
       }
     }

--- a/test/fixtures/templates/interpolate/fileWithGruntConfig.js
+++ b/test/fixtures/templates/interpolate/fileWithGruntConfig.js
@@ -1,0 +1,2 @@
+<%= generate.options.src %>
+<%= generate.options.dest %>

--- a/test/generate_test.js
+++ b/test/generate_test.js
@@ -155,5 +155,22 @@ module.exports = {
       test.ok( expect( err ).not.to.be.undefined );
       test.done();
     } );
+  },
+
+  'should expose grunt config to templates': function (test) {
+    grunt.util.spawn({
+      grunt: true,
+      args: ['generate:interpolate/fileWithGruntConfig:file'].concat(defaultArgs)
+    }, function (err, result) {
+      err && test.fail(result.stdout);
+      test.expect( 2 );
+      test.ok( expect(
+        grunt.file.read( 'test/fixtures/generated/dest/interpolated/file.js' )
+      ).to.contain( 'templates' ));
+      test.ok( expect(
+        grunt.file.read( 'test/fixtures/generated/dest/interpolated/file.js' )
+      ).to.contain( 'generated/dest' ));
+      test.done();
+    });
   }
 };


### PR DESCRIPTION
I found that the only 2 properties that can be used are `file` and `meta`. No other grunt config variables are available.

My usecase is:
I use [grunt-prompt](https://github.com/dylang/grunt-prompt) to configure a setting file. User provides 3 values and grunt-prompt stores them in the grunt.config object.
I want to use them in grunt-generate then, but they're not processed.
Neither do values set in `grunt.config.init`

I took a look into the code and I found:

``` javascript
    var data = {
      file : destination,
      meta : {
        className : _s.classify( destination.name ),
        type      : source.path.replace( '/', '.' ),
        package   : _s.camelize( destination.dir.replace( '/', '.', 'g' ) )
      }
    };
    data.meta.fqn = data.meta.package + '.' + data.meta.className;

    var processed = grunt.template.process( grunt.file.read( source.absolute ), {
      data : data
    } );
```

It does not look like any of the config variables are passed to the `grunt.template.process` explicitly.

After adding:

```
    var _ = require( 'underscore' );
    var processed = grunt.template.process( grunt.file.read( source.absolute ), {
      data : data : _.extend({}, grunt.config.data, data)
    } );
```

it works well.     
