### PR TITLE
Allow multiple file extensions in template names

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
     "gruntfile"
   ],
   "dependencies": {
-    "underscore.string": "^2.3.3",
     "inquirer": "^0.4.1",
-    "lodash": "^2.4.1"
+    "lodash": "^2.4.1",
+    "path-complete-extname": "^0.1.0",
+    "underscore.string": "^2.3.3"
   }
 }

--- a/tasks/generate.js
+++ b/tasks/generate.js
@@ -12,6 +12,7 @@ var path = require( 'path' );
 var _ = require( 'lodash' );
 var _s = require( 'underscore.string' );
 var inquirer = require( 'inquirer' );
+var pathCompleteExtname = require('path-complete-extname');
 
 module.exports = function( grunt ){
 
@@ -62,7 +63,7 @@ module.exports = function( grunt ){
 
     source.relative = files[0];
     source.absolute = path.resolve( source.relative );
-    source.ext = path.extname( source.relative );
+    source.ext = pathCompleteExtname( source.relative );
     destination.basename = destination.name + source.ext;
 
     var mapping;

--- a/test/fixtures/Gruntfile.js
+++ b/test/fixtures/Gruntfile.js
@@ -24,7 +24,8 @@ module.exports = function( grunt ){
           "constructed"             : ':dir/constructed',
           "constructed/ExtraModule" : ':dir/constructed/stub_:basename',
           "interpolate"             : 'interpolated',
-          "grunt"                   : 'grunt'
+          "grunt"                   : 'grunt',
+          "extension"               : 'extension'
         }
       }
     }

--- a/test/fixtures/templates/extension/class.es6.js
+++ b/test/fixtures/templates/extension/class.es6.js
@@ -1,0 +1,5 @@
+export default class <%= file.name %> {
+  constructor() {
+
+  }
+}

--- a/test/fixtures/templates/extension/page.html
+++ b/test/fixtures/templates/extension/page.html
@@ -1,0 +1,6 @@
+<!DOCTYPE>
+<html>
+<head>
+  <title><%= file.basename %></title>
+</head>
+</html>

--- a/test/generate_test.js
+++ b/test/generate_test.js
@@ -184,6 +184,32 @@ module.exports = {
       test.ok( expect( generated.src ).to.equal( 'templates' ) );
       test.done();
     } );
+  },
+
+  'should recreate file extension': function( test ) {
+    grunt.util.spawn( {
+      grunt : true,
+      args  : ['generate:extension/page:file'].concat( defaultArgs )
+    }, function( err,
+                 result ){
+      err && test.fail( result.stdout );
+      test.expect( 1 );
+      test.ok( grunt.file.exists( 'test/fixtures/generated/dest/extension/file.html' ) );
+      test.done();
+    } );
+  },
+
+  'should recreate multiple file extensions': function( test ) {
+    grunt.util.spawn( {
+      grunt : true,
+      args  : ['generate:extension/class:file'].concat( defaultArgs )
+    }, function( err,
+                 result ){
+      err && test.fail( result.stdout );
+      test.expect( 1 );
+      test.ok( grunt.file.exists( 'test/fixtures/generated/dest/extension/file.es6.js' ) );
+      test.done();
+    } );
   }
 
 };


### PR DESCRIPTION
Currently, a template named `class.es6.js` would produce a file named `*.js`. To work well with things like transpilers, syntax highlighters, and certain workflows, it should include all extension names (`*.es6.js`).
